### PR TITLE
Allow build with CMake 4.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.10)
 project(libldac
         LANGUAGES C
         VERSION 2.0.2.3)


### PR DESCRIPTION
use min...max syntax to allow build with newer cmake.

ref: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html